### PR TITLE
cubic_roots now accepts polynomials of degrees lower than 3

### DIFF
--- a/cubic/cardano.py
+++ b/cubic/cardano.py
@@ -12,9 +12,26 @@ def cubic_roots(a, b, c, d):
     
     This function does not check if the found roots are real or complex.
     """
-    delta_0 = b**2 - 3*a*c
-    delta_1 = 2*b**3 - 9*a*b*c + 27*a**2*d
-    C = ((delta_1 + np.sqrt(delta_1**2 - 4*delta_0**3 + 0j)) / 2)**(1/3)
-    zeta = -1/2 + 1j/2 * np.sqrt(3)
-    return [-1/(3*a) * (b + zeta**k * C + delta_0 / (zeta**k * C))
-            for k in [0, 1, 2]]
+    if (a != 0): # Case: ax^3 + bx^2 + cx + d = 0
+        delta_0 = b**2 - 3*a*c
+        delta_1 = 2*b**3 - 9*a*b*c + 27*a**2*d
+        C = ((delta_1 + np.sqrt(delta_1**2 - 4*delta_0**3 + 0j)) / 2)**(1/3)
+        zeta = -1/2 + 1j/2 * np.sqrt(3)
+        return [-1/(3*a) * (b + zeta**k * C + delta_0 / (zeta**k * C))
+                for k in [0, 1, 2]]
+        
+    elif (b != 0): # Case: bx^2 + cx + d = 0
+        delta = c**2 - 4*b*d
+        return [(-c + (-1)**k*np.sqrt(delta + 0j))/(2*b)
+                for k in [0, 1]]
+    
+    elif (c != 0): # Case: cx + d = 0
+        return -d/c
+    
+    elif (d != 0): # Case: d = 0 (without solution)
+        return np.nan
+    
+    else: # Case: d = 0 (with trivial solution)
+        return 0
+        
+

--- a/cubic/cardano.py
+++ b/cubic/cardano.py
@@ -22,16 +22,14 @@ def cubic_roots(a, b, c, d):
         
     elif (b != 0): # Case: bx^2 + cx + d = 0
         delta = c**2 - 4*b*d
-        return [(-c + (-1)**k*np.sqrt(delta + 0j))/(2*b)
-                for k in [0, 1]]
+        return [(-c + k*np.sqrt(delta + 0j))/(2*b)
+                for k in [-1, 1]]
     
     elif (c != 0): # Case: cx + d = 0
         return -d/c
     
-    elif (d != 0): # Case: d = 0 (without solution)
+    elif (d != 0): # Case: d != 0 (without solution)
         return np.nan
     
     else: # Case: d = 0 (with trivial solution)
         return 0
-        
-


### PR DESCRIPTION
The function cubic_roots now can handle polynomials of lower degree.

Useful for inputs like: `cubic_roots(0, 1, 1, 1)`